### PR TITLE
Remove distance-based stopping

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v0.10.0"
+current_version = "v1.0.0"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # invrs-utils - Miscellaneous utilities
-`v0.10.0`
+`v1.0.0`
 
 This package is a collection of utilities that may be useful, but do not have fundamental roles in the invrs-io ecosystem. These currently include,
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "invrs_utils"
-version = "v0.10.0"
+version = "v1.0.0"
 description = "Miscellaneous utilities for the invrs-io ecosystem"
 keywords = ["topology", "optimization", "jax", "inverse design"]
 readme = "README.md"

--- a/src/invrs_utils/__init__.py
+++ b/src/invrs_utils/__init__.py
@@ -3,5 +3,5 @@
 Copyright (c) 2023 The INVRS-IO authors.
 """
 
-__version__ = "v0.10.0"
+__version__ = "v1.0.0"
 __author__ = "Martin F. Schubert <mfschubert@gmail.com>"

--- a/tests/experiment/test_gym_experiment.py
+++ b/tests/experiment/test_gym_experiment.py
@@ -32,8 +32,6 @@ class GymExperimentTest(unittest.TestCase):
                     challenge=challenges.metagrating(),
                     optimizer=invrs_opt.density_lbfgsb(beta=beta),
                     steps=steps,
-                    stop_on_zero_distance=False,
-                    stop_requires_binary=True,
                     num_replicas=num_replicas,
                 )
 

--- a/tests/experiment/test_work_unit.py
+++ b/tests/experiment/test_work_unit.py
@@ -39,40 +39,11 @@ def dummy_challenge():
             return jnp.sum(response**2)
 
         def eval_metric(self, response):
-            return 1 - jnp.sum(response) ** 2
-
-        def _distance_to_target(self, response):
-            return jnp.sum(jnp.abs(response)) - 0.1
+            return -self.loss(response)
 
         def metrics(self, response, params, aux):
             metrics = super().metrics(response, params, aux)
-            metrics.update({"distance_to_target": self._distance_to_target(response)})
             return metrics
-
-    return DummyChallenge(component=DummyComponent())
-
-
-def dummy_challenge_with_no_distance_metric():
-    class DummyComponent(challenge_base.Component):
-        def init(self, key):
-            del key
-            return {"array": jnp.arange(100).reshape(10, 10).astype(float)}
-
-        def response(self, params):
-            return jnp.sum(params["array"], axis=0), {}
-
-    @dataclasses.dataclass
-    class DummyChallenge(challenge_base.Challenge):
-        component: challenge_base.Component
-
-        def loss(self, response):
-            return jnp.sum(response**2)
-
-        def eval_metric(self, response):
-            return 1 - jnp.sum(response) ** 2
-
-        def metrics(self, response, params, aux):
-            return super().metrics(response, params, aux)
 
     return DummyChallenge(component=DummyComponent())
 
@@ -96,14 +67,10 @@ def dummy_challenge_with_density():
             return jnp.sum(response**2)
 
         def eval_metric(self, response):
-            return 1 - jnp.sum(response) ** 2
-
-        def _distance_to_target(self, response):
-            return jnp.sum(jnp.abs(response)) - 0.1
+            return -self.loss(response)
 
         def metrics(self, response, params, aux):
             metrics = super().metrics(response, params, aux)
-            metrics.update({"distance_to_target": self._distance_to_target(response)})
             return metrics
 
     return DummyChallenge(component=DummyComponent())
@@ -114,39 +81,17 @@ class WorkUnitTest(unittest.TestCase):
         [
             [
                 dummy_challenge,
-                {
-                    "loss",
-                    "distance_to_target",
-                    "step_time",
-                },
-                1,
-            ],
-            [
-                dummy_challenge_with_no_distance_metric,
-                {
-                    "loss",
-                    "step_time",
-                },
+                {"loss", "step_time", "eval_metric"},
                 1,
             ],
             [
                 dummy_challenge_with_density,
-                {
-                    "loss",
-                    "distance_to_target",
-                    "step_time",
-                    "binarization_degree",
-                },
+                {"loss", "step_time", "binarization_degree", "eval_metric"},
                 1,
             ],
             [
                 dummy_challenge_with_density,
-                {
-                    "loss",
-                    "distance_to_target",
-                    "step_time",
-                    "binarization_degree",
-                },
+                {"loss", "step_time", "binarization_degree", "eval_metric"},
                 10,
             ],
         ]
@@ -169,8 +114,6 @@ class WorkUnitTest(unittest.TestCase):
                     challenge=challenge_fn(),
                     optimizer=invrs_opt.lbfgsb(maxcor=20),
                     steps=100,
-                    stop_on_zero_distance=False,
-                    stop_requires_binary=True,
                     save_interval_steps=10,
                     max_to_keep=3,
                     num_replicas=num_replicas,
@@ -197,60 +140,9 @@ class WorkUnitTest(unittest.TestCase):
                 jnp.amin(ckpt["scalars"]["loss"], axis=0),
                 ckpt["champion_result"]["loss"],
             )
-
-    @parameterized.expand(
-        [
-            [dummy_challenge, 1, True],
-            [dummy_challenge_with_density, 1, True],
-            [dummy_challenge_with_density, 10, True],
-            [dummy_challenge_with_no_distance_metric, 1, False],
-        ]
-    )
-    def test_optimize_with_early_stopping(
-        self, challenge_fn, num_replicas, should_stop_early
-    ):
-        with tempfile.TemporaryDirectory() as wid_path:
-
-            def _run_work_unit():
-                if not os.path.exists(wid_path):
-                    os.makedirs(wid_path)
-
-                work_unit_config = locals()
-                del work_unit_config["challenge_fn"]
-                with open(wid_path + "/setup.json", "w") as f:
-                    json.dump(work_unit_config, f, indent=4)
-
-                work_unit.run_work_unit(
-                    key=jax.random.PRNGKey(0),
-                    wid_path=wid_path,
-                    challenge=challenge_fn(),
-                    optimizer=invrs_opt.lbfgsb(maxcor=20),
-                    steps=100,
-                    stop_on_zero_distance=True,
-                    stop_requires_binary=True,
-                    save_interval_steps=10,
-                    max_to_keep=1,
-                    num_replicas=num_replicas,
-                )
-
-            _run_work_unit()
-
-            latest_step = checkpoint.latest_step(wid_path)
-            if should_stop_early:
-                self.assertLess(latest_step, 99)
-            print(glob.glob(f"{wid_path}/*"))
-            self.assertSequenceEqual(
-                set(glob.glob(f"{wid_path}/*")),
-                {
-                    f"{wid_path}/setup.json",
-                    f"{wid_path}/completed.txt",
-                    f"{wid_path}/checkpoint_{latest_step:04}.json",
-                },
-            )
-            ckpt = checkpoint.load(wid_path, step=latest_step)
             onp.testing.assert_array_equal(
-                jnp.amin(ckpt["scalars"]["loss"], axis=0),
-                ckpt["champion_result"]["loss"],
+                jnp.amax(ckpt["scalars"]["eval_metric"], axis=0),
+                ckpt["champion_result"]["eval_metric"],
             )
 
     @parameterized.expand(
@@ -279,8 +171,6 @@ class WorkUnitTest(unittest.TestCase):
                     challenge=challenge_fn(),
                     optimizer=invrs_opt.lbfgsb(maxcor=20),
                     steps=5,
-                    stop_on_zero_distance=True,
-                    stop_requires_binary=True,
                     champion_requires_binary=False,
                     save_interval_steps=10,
                     max_to_keep=3,
@@ -301,6 +191,6 @@ class WorkUnitTest(unittest.TestCase):
             )
             ckpt = checkpoint.load(wid_path, step=latest_step)
             onp.testing.assert_array_equal(
-                jnp.amin(ckpt["scalars"]["loss"], axis=0),
-                ckpt["champion_result"]["loss"],
+                jnp.amax(ckpt["scalars"]["eval_metric"], axis=0),
+                ckpt["champion_result"]["eval_metric"],
             )


### PR DESCRIPTION
Release a major new version with the following changes, supporting gym v1.0.0
- remove references to `distance_to_target`, in summarization and experiment code
- include `eval_metric` in experiment summarization