### PR TITLE
strip out multiprocessing capability

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v1.2.0"
+current_version = "v1.3.0"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # invrs-utils - Miscellaneous utilities
-`v1.2.0`
+`v1.3.0`
 
 This package is a collection of utilities that may be useful, but do not have fundamental roles in the invrs-io ecosystem. These currently include,
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "invrs_utils"
-version = "v1.2.0"
+version = "v1.3.0"
 description = "Miscellaneous utilities for the invrs-io ecosystem"
 keywords = ["topology", "optimization", "jax", "inverse design"]
 readme = "README.md"

--- a/src/invrs_utils/__init__.py
+++ b/src/invrs_utils/__init__.py
@@ -3,5 +3,5 @@
 Copyright (c) 2023 The INVRS-IO authors.
 """
 
-__version__ = "v1.2.0"
+__version__ = "v1.3.0"
 __author__ = "Martin F. Schubert <mfschubert@gmail.com>"

--- a/src/invrs_utils/experiment/experiment.py
+++ b/src/invrs_utils/experiment/experiment.py
@@ -4,7 +4,6 @@ Copyright (c) 2023 The INVRS-IO authors.
 """
 
 import json
-import multiprocessing as mp
 import os
 import random
 import time
@@ -20,7 +19,6 @@ def run_experiment(
     experiment_path: str,
     sweeps: Sequence[Dict[str, Any]],
     work_unit_fn: Callable[[Any], Any],
-    workers: int,
     dry_run: bool,
     randomize: bool,
 ) -> None:
@@ -31,7 +29,6 @@ def run_experiment(
     # Print some information about the experiment.
     print(
         f"Experiment {experiment_path.split('/')[-1]} (path={experiment_path}, "
-        f"workers={max(1, workers)}, "
         f"work_units={len(sweeps)})"
     )
     for wid_path, kwargs in zip(wid_paths, sweeps):
@@ -54,11 +51,7 @@ def run_experiment(
     if dry_run:
         return
 
-    if workers == 1:
-        _ = list(map(work_unit_fn, path_and_kwargs))
-    else:
-        with mp.Pool(processes=workers) as pool:
-            _ = list(pool.imap_unordered(work_unit_fn, path_and_kwargs))
+    list(map(work_unit_fn, path_and_kwargs))
 
 
 def work_unit_fn(fn: Any) -> Callable[[Tuple[str, Dict[str, Any]]], Any]:

--- a/tests/experiment/test_experiment.py
+++ b/tests/experiment/test_experiment.py
@@ -40,7 +40,6 @@ class ExperimentTest(unittest.TestCase):
                 experiment_path=experiment_path,
                 sweeps=sweeps,
                 work_unit_fn=work_unit_fn,
-                workers=1,
                 randomize=True,
                 dry_run=False,
             )

--- a/tests/experiment/test_gym_experiment.py
+++ b/tests/experiment/test_gym_experiment.py
@@ -43,7 +43,6 @@ class GymExperimentTest(unittest.TestCase):
                 experiment_path=experiment_path,
                 sweeps=sweeps,
                 work_unit_fn=work_unit_fn,
-                workers=1,
                 dry_run=False,
                 randomize=False,
             )
@@ -60,7 +59,6 @@ class GymExperimentTest(unittest.TestCase):
                 experiment_path=experiment_path,
                 sweeps=sweeps,
                 work_unit_fn=work_unit_fn,
-                workers=1,
                 dry_run=False,
                 randomize=False,
             )


### PR DESCRIPTION
Parallel processing is currently broken, and has been for some time. Remove it; it can be re-added if needed later.